### PR TITLE
feat: add input and button component to add and delete routes

### DIFF
--- a/src/components/button/button.css.tsx
+++ b/src/components/button/button.css.tsx
@@ -1,0 +1,28 @@
+import styled, { css } from 'styled-components';
+import { colours, fontSizes } from 'styles';
+
+interface ContainerProps {
+  disabled: boolean;
+}
+
+export const Container = styled.button<ContainerProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3rem;
+  background: ${colours.buttonPrimary};
+  color: ${colours.secondary};
+  border-radius: 0.5rem;
+  font-size: ${fontSizes.normal}rem;
+  cursor: pointer;
+
+  &:hover {
+    background: ${colours.buttonHover};
+  }
+
+  ${({ disabled }: ContainerProps) =>
+    disabled &&
+    css`
+      color: ${colours.buttonDisabled};
+    `}
+`;

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import 'jest-styled-components';
+import { render, fireEvent } from '@testing-library/react';
+import Button, { Props } from './button';
+
+describe('Button tests', (): void => {
+  const defaultProps: Props = {
+    onClick: jest.fn(),
+  };
+
+  it('renders the button with children', (): void => {
+    // given
+    const { container, getByText } = render(
+      <Button {...defaultProps}>
+        <span>Test</span>
+      </Button>,
+    );
+
+    // then
+    expect(container).toBeTruthy();
+    expect(getByText('Test')).toBeTruthy();
+  });
+
+  it('executes a callback on click', (): void => {
+    // given
+    const spyOnClick = jest.fn();
+    const { getByTestId } = render(
+      <Button {...defaultProps} onClick={spyOnClick}>
+        <span>Test</span>
+      </Button>,
+    );
+
+    // then
+    fireEvent.click(getByTestId('button'));
+    expect(spyOnClick).toHaveBeenCalled();
+  });
+
+  it('applies the correct style for a disabled button', (): void => {
+    // given
+    const { getByTestId } = render(
+      <Button {...defaultProps} disabled>
+        <span>Test</span>
+      </Button>,
+    );
+
+    // then
+    expect(getByTestId('button')).toHaveStyleRule('display', 'flex');
+  });
+});

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Container } from './button.css';
+
+export interface Props {
+  children?: any;
+  className?: string;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+const Button = ({ children, className, disabled = false, onClick }: Props): JSX.Element => (
+  <Container data-testid="button" className={className} disabled={disabled} onClick={onClick}>
+    {children}
+  </Container>
+);
+
+export default Button;

--- a/src/components/input/input.css.tsx
+++ b/src/components/input/input.css.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import { colours, fontSizes } from 'styles';
+
+export const Container = styled.input`
+  height: 3rem;
+  margin-right: 1rem;
+  border: none;
+  border-bottom: 1px solid ${colours.primary};
+  background: inherit;
+  color: ${colours.primary};
+  font-size: ${fontSizes.normal}rem;
+
+  &:focus,
+  &:hover {
+    border-bottom: 2px solid ${colours.primary};
+    outline: none;
+  }
+`;

--- a/src/components/input/input.test.tsx
+++ b/src/components/input/input.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Input, { Props } from './input';
+
+describe('Input tests', (): void => {
+  const spyOnBlur = jest.fn();
+  const spyOnChange = jest.fn();
+  const spyOnFocus = jest.fn();
+  const defaultProps: Props = {
+    onBlur: spyOnBlur,
+    onChange: spyOnChange,
+    onFocus: spyOnFocus,
+    placeholder: 'Test',
+  };
+
+  beforeEach((): void => {
+    spyOnBlur.mockClear();
+    spyOnChange.mockClear();
+    spyOnFocus.mockClear();
+  });
+
+  it('renders the component and works with default callbacks', (): void => {
+    const { container, getByTestId } = render(<Input />);
+    const input = getByTestId('input');
+
+    fireEvent.blur(input);
+    fireEvent.change(input, { target: { value: 'T' } });
+    fireEvent.focus(input);
+
+    expect(container).toBeTruthy();
+  });
+
+  it('should execute a callback on blur, change and focus', (): void => {
+    // given
+    const { getByTestId } = render(
+      <Input {...defaultProps} onBlur={spyOnBlur} onChange={spyOnChange} onFocus={spyOnFocus} />,
+    );
+    const input = getByTestId('input');
+
+    // then
+    fireEvent.blur(input);
+    fireEvent.change(input, { target: { value: 'T' } });
+    fireEvent.focus(input);
+    expect(spyOnBlur).toHaveBeenCalled();
+    expect(spyOnChange).toHaveBeenCalled();
+    expect(spyOnFocus).toHaveBeenCalled();
+  });
+});

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Container } from './input.css';
+
+export interface Props {
+  onBlur?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  className?: string;
+  disabled?: boolean;
+  placeholder?: string;
+  value?: string;
+}
+
+const Input = ({
+  className,
+  disabled = false,
+  onBlur,
+  onChange,
+  onFocus,
+  placeholder = '',
+  value,
+}: Props): JSX.Element => (
+  <Container
+    className={className}
+    data-testid="input"
+    disabled={disabled}
+    onBlur={onBlur}
+    onChange={onChange}
+    onFocus={onFocus}
+    placeholder={placeholder}
+    value={value}
+  />
+);
+
+export default Input;

--- a/src/components/routes/actionTypes.ts
+++ b/src/components/routes/actionTypes.ts
@@ -1,6 +1,7 @@
 enum ActionTypes {
   ADD_ROUTE = 'ADD_ROUTE',
   DELETE_ROUTE = 'DELETE_ROUTE',
+  UPDATE_NEW_ROUTE_TITLE = 'UPDATE_NEW_ROUTE_TITLE',
 }
 
 export default ActionTypes;

--- a/src/components/routes/actions.test.ts
+++ b/src/components/routes/actions.test.ts
@@ -1,6 +1,6 @@
 import { Route } from 'models';
 import ActionTypes from './actionTypes';
-import { addRoute, deleteRoute } from './actions';
+import { addRoute, deleteRoute, updateNewRouteTitle } from './actions';
 
 describe('routes action tests', (): void => {
   const route: Route = {
@@ -12,8 +12,7 @@ describe('routes action tests', (): void => {
   };
 
   it('adds a route', (): void => {
-    expect(addRoute(route)).toEqual({
-      payload: route,
+    expect(addRoute()).toEqual({
       type: ActionTypes.ADD_ROUTE,
     });
   });
@@ -22,6 +21,13 @@ describe('routes action tests', (): void => {
     expect(deleteRoute(route)).toEqual({
       payload: route,
       type: ActionTypes.DELETE_ROUTE,
+    });
+  });
+
+  it('updates the title for a new route', (): void => {
+    expect(updateNewRouteTitle('Test title')).toEqual({
+      payload: 'Test title',
+      type: ActionTypes.UPDATE_NEW_ROUTE_TITLE,
     });
   });
 });

--- a/src/components/routes/actions.ts
+++ b/src/components/routes/actions.ts
@@ -3,7 +3,6 @@ import ActionTypes from './actionTypes';
 
 interface AddRoute {
   type: typeof ActionTypes.ADD_ROUTE;
-  payload: Route;
 }
 
 interface DeleteRoute {
@@ -11,14 +10,23 @@ interface DeleteRoute {
   payload: Route;
 }
 
-export type RoutesActionTypes = AddRoute | DeleteRoute;
+interface UpdateNewRouteTitle {
+  type: typeof ActionTypes.UPDATE_NEW_ROUTE_TITLE;
+  payload: string;
+}
 
-export const addRoute = (route: Route): RoutesActionTypes => ({
+export type RoutesActionTypes = AddRoute | DeleteRoute | UpdateNewRouteTitle;
+
+export const addRoute = (): RoutesActionTypes => ({
   type: ActionTypes.ADD_ROUTE,
-  payload: route,
 });
 
 export const deleteRoute = (route: Route): RoutesActionTypes => ({
   type: ActionTypes.DELETE_ROUTE,
   payload: route,
+});
+
+export const updateNewRouteTitle = (title: string): RoutesActionTypes => ({
+  type: ActionTypes.UPDATE_NEW_ROUTE_TITLE,
+  payload: title,
 });

--- a/src/components/routes/connectedRoutes.tsx
+++ b/src/components/routes/connectedRoutes.tsx
@@ -2,21 +2,25 @@ import React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import { Route } from 'models';
-import { addRoute, deleteRoute, RoutesActionTypes } from './actions';
+import { addRoute, deleteRoute, updateNewRouteTitle, RoutesActionTypes } from './actions';
 import Routes, { Props } from './routes';
 
 const mapStateToProps = (state: any) => ({
   error: state.routesState.error,
+  newRouteTitle: state.routesState.newRouteTitle,
   pending: state.routesState.pending,
   routes: state.routesState.routes,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<RoutesActionTypes>) => ({
-  addRoute: (route: Route): void => {
-    dispatch<any>(addRoute(route));
+  addRoute: (): void => {
+    dispatch<any>(addRoute());
   },
   deleteRoute: (route: Route): void => {
     dispatch<any>(deleteRoute(route));
+  },
+  updateNewRouteTitle: (title: string): void => {
+    dispatch<any>(updateNewRouteTitle(title));
   },
 });
 

--- a/src/components/routes/reducer.test.ts
+++ b/src/components/routes/reducer.test.ts
@@ -12,16 +12,30 @@ describe('routes reducer test', (): void => {
   };
 
   it('sets the state when adding a route', (): void => {
-    const state = reducer(undefined, {
-      type: ActionTypes.ADD_ROUTE,
-      payload: route,
-    });
+    const state = reducer(
+      {
+        ...initialState,
+        newRouteTitle: 'Test Route',
+      },
+      {
+        type: ActionTypes.ADD_ROUTE,
+      },
+    );
     const check = {
       ...initialState,
       routes: [route],
     };
 
-    expect(state).toEqual(check);
+    expect(check).toMatchObject({
+      ...state,
+      routes: [
+        {
+          ...route,
+          dateCreated: expect.any(Date),
+          id: expect.any(String),
+        },
+      ],
+    });
   });
 
   it('sets the state when deleting a route', (): void => {
@@ -41,5 +55,18 @@ describe('routes reducer test', (): void => {
     );
 
     expect(state.routes).toEqual([route]);
+  });
+
+  it('sets the state when updating a route title', (): void => {
+    const state = reducer(initialState, {
+      payload: 'A new route',
+      type: ActionTypes.UPDATE_NEW_ROUTE_TITLE,
+    });
+    const check = {
+      ...initialState,
+      newRouteTitle: 'A new route',
+    };
+
+    expect(state).toEqual(check);
   });
 });

--- a/src/components/routes/reducer.ts
+++ b/src/components/routes/reducer.ts
@@ -1,8 +1,11 @@
+import { v4 as uuidv4 } from 'uuid';
 import { Route, RoutesState, ReduxAction } from 'models';
+import { slugify } from 'utils';
 import ActionTypes from './actionTypes';
 
 export const initialState: RoutesState = {
   error: null,
+  newRouteTitle: '',
   pending: false,
   routes: [],
 };
@@ -10,12 +13,19 @@ export const initialState: RoutesState = {
 const reducer = (state: RoutesState = initialState, { payload, type }: ReduxAction): RoutesState => {
   switch (type) {
     case ActionTypes.ADD_ROUTE: {
-      const route = payload;
+      const { newRouteTitle } = state;
+      const newRoute: Route = {
+        dateCreated: new Date(),
+        id: uuidv4(),
+        slug: slugify(newRouteTitle),
+        title: newRouteTitle,
+      };
       const { routes } = state;
 
       return {
         ...state,
-        routes: [...routes, route],
+        newRouteTitle: '',
+        routes: [...routes, newRoute],
       };
     }
 
@@ -27,6 +37,15 @@ const reducer = (state: RoutesState = initialState, { payload, type }: ReduxActi
       return {
         ...state,
         routes: filteredRoutes,
+      };
+    }
+
+    case ActionTypes.UPDATE_NEW_ROUTE_TITLE: {
+      const newRouteTitle: string = payload;
+
+      return {
+        ...state,
+        newRouteTitle,
       };
     }
 

--- a/src/components/routes/routes.css.tsx
+++ b/src/components/routes/routes.css.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 import SidebarComponent from 'components/sidebar/sidebar';
+import ButtonComponent from 'components/button/button';
+import InputComponent from 'components/input/input';
 import MapComponent from 'components/map/map';
 
 export const Container = styled.div`
@@ -12,7 +14,31 @@ export const Container = styled.div`
 `;
 
 export const Sidebar = styled(SidebarComponent)`
+  padding: 1rem;
   grid-area: sidebar;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr 5rem;
+  grid-template-areas:
+    'route-list'
+    'add-route';
+`;
+
+export const RouteList = styled.ul`
+  grid-area: route-list;
+`;
+
+export const AddRoute = styled.div`
+  grid-area: add-route;
+  display: flex;
+`;
+
+export const Input = styled(InputComponent)`
+  flex: 3;
+`;
+
+export const Button = styled(ButtonComponent)`
+  flex: 1;
 `;
 
 export const Map = styled(MapComponent)`

--- a/src/components/routes/routes.test.tsx
+++ b/src/components/routes/routes.test.tsx
@@ -1,16 +1,74 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { renderWithRouter } from 'utils/testutils';
+import { Route } from 'models';
 import Routes, { Props } from './routes';
 
 describe('Routes tests', (): void => {
+  const routes: Route[] = [
+    {
+      dateCreated: new Date(),
+      id: '1234',
+      slug: 'test-route-one',
+      title: 'Test Route One',
+    },
+    {
+      dateCreated: new Date(),
+      id: '5678',
+      slug: 'test-route-two',
+      title: 'Test Route Two',
+    },
+  ];
   const defaultProps: Props = {
     addRoute: jest.fn(),
     deleteRoute: jest.fn(),
+    updateNewRouteTitle: jest.fn(),
+
+    newRouteTitle: '',
     pending: false,
-    routes: [],
+    routes,
   };
 
-  it('renders the component', (): void => {
-    expect(render(<Routes {...defaultProps} />)).toBeTruthy();
+  it('renders the component with route tiles', (): void => {
+    // given
+    const { container, getByText } = renderWithRouter(<Routes {...defaultProps} />);
+
+    // then
+    expect(container).toBeTruthy();
+    expect(getByText('Test Route One')).toBeTruthy();
+    expect(getByText('Test Route Two')).toBeTruthy();
+  });
+
+  it('should update the title for a new route', (): void => {
+    // given
+    const spyUpdateNewRouteTitle = jest.fn();
+    const { getByTestId } = renderWithRouter(<Routes {...defaultProps} updateNewRouteTitle={spyUpdateNewRouteTitle} />);
+
+    // then
+    fireEvent.change(getByTestId('input'), {
+      target: {
+        value: 'New Route',
+      },
+    });
+    expect(spyUpdateNewRouteTitle).toHaveBeenCalledWith('New Route');
+  });
+
+  it('should call to add a route on button click', (): void => {
+    // given
+    const spyAddRoute = jest.fn();
+    const { getByTestId } = renderWithRouter(<Routes {...defaultProps} addRoute={spyAddRoute} />);
+
+    // then
+    fireEvent.click(getByTestId('button'));
+    expect(spyAddRoute).toHaveBeenCalled();
+  });
+
+  it('should call to delete a route', (): void => {
+    const spyDeleteRoute = jest.fn();
+    const { getAllByTestId } = renderWithRouter(<Routes {...defaultProps} deleteRoute={spyDeleteRoute} />);
+
+    // then
+    fireEvent.click(getAllByTestId('delete')[0]);
+    expect(spyDeleteRoute).toHaveBeenCalledWith(routes[0]);
   });
 });

--- a/src/components/routes/routes.tsx
+++ b/src/components/routes/routes.tsx
@@ -1,38 +1,46 @@
-import React, { useEffect } from 'react';
-import { v4 as uuid } from 'uuid';
+import React from 'react';
 import { Route } from 'models';
 import RouteTile from 'components/routetile/routetile';
-import { Container, Map, Sidebar } from './routes.css';
+import { AddRoute, Button, Container, Input, Map, RouteList, Sidebar } from './routes.css';
 
 export interface Props {
-  addRoute(route: Route): void;
+  addRoute(): void;
   deleteRoute(route: Route): void;
+  updateNewRouteTitle(title: string): void;
 
   className?: string;
   error?: any;
+  newRouteTitle: string;
   pending: boolean;
   routes: Route[];
 }
 
-const Routes = ({ addRoute, className, routes }: Props): JSX.Element => {
-  useEffect((): void => {
-    const dummy: Route = {
-      dateCreated: new Date(),
-      id: uuid(),
-      note: 'Test note',
-      slug: 'test-route',
-      title: 'Test Route',
-    };
-
-    addRoute(dummy);
-  }, []);
+const Routes = ({
+  addRoute,
+  className,
+  deleteRoute,
+  newRouteTitle,
+  routes,
+  updateNewRouteTitle,
+}: Props): JSX.Element => {
+  const onInputChange = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>): void => {
+    updateNewRouteTitle(value);
+  };
 
   return (
     <Container className={className}>
       <Sidebar>
-        {routes?.map((item: Route) => (
-          <RouteTile key={item.id} route={item} onClickDelete={console.log} />
-        ))}
+        <RouteList>
+          {routes?.map((item: Route) => (
+            <RouteTile key={item.id} route={item} onClickDelete={deleteRoute} />
+          ))}
+        </RouteList>
+        <AddRoute>
+          <Input onChange={onInputChange} placeholder="Add a new route" value={newRouteTitle} />
+          <Button onClick={addRoute}>
+            <span>Add</span>
+          </Button>
+        </AddRoute>
       </Sidebar>
       <Map />
     </Container>

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -21,6 +21,7 @@ export interface ReduxAction {
 
 export interface RoutesState {
   error: any;
+  newRouteTitle: string;
   pending: boolean;
   routes: Route[];
 }

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -6,6 +6,8 @@ export type Colours = {
   primary: string;
   secondary: string;
   buttonPrimary: string;
+  buttonHover: string;
+  buttonDisabled: string;
   iconPrimary: string;
 };
 

--- a/src/styles/vars.ts
+++ b/src/styles/vars.ts
@@ -3,7 +3,9 @@ import { Colours, FontSizes } from 'models';
 export const colours: Colours = {
   primary: 'rgb(255, 255, 255)',
   secondary: 'rgb(42, 42, 42)',
-  buttonPrimary: 'rgb(182, 225, 65)',
+  buttonPrimary: 'rgb(101, 173, 21)',
+  buttonHover: 'rgb(182, 225, 65)',
+  buttonDisabled: 'rgba(101, 173, 21, 0.5)',
   iconPrimary: 'rgb(97, 97, 97)',
 };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,9 @@
+import { slugify } from './utils';
+
+describe('Test utils', (): void => {
+  it('should convert strings to slugs', (): void => {
+    expect(slugify()).toEqual('');
+    expect(slugify('Run around Howth')).toEqual('run-around-howth');
+    expect(slugify('Run around Peenemünde')).toEqual('run-around-peenemunde');
+  });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,6 @@
+export const slugify = (str = ''): string =>
+  str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\W+/g, '-');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = (env, { mode }) => ({
       'components': path.resolve(__dirname, 'src/components'),
       'models': path.resolve(__dirname, 'src/models'),
       'styles': path.resolve(__dirname, 'src/styles'),
+      'utils': path.resolve(__dirname, 'src/utils'),
     },
     extensions: ['.ts', '.tsx', '.js']
   },


### PR DESCRIPTION
## What is this?
This PR focuses on adding and deleting routes and has the following changes:
- added button and input components with styling and tests
- updated the reducer and actions for the routes component to allow for adding and deleting of routes