### PR TITLE
feat: add waypoint tile with styling and tests

### DIFF
--- a/src/components/map/map.test.tsx
+++ b/src/components/map/map.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Waypoint } from 'models';
 import * as googleServices from 'services/googlemaps';
 import Map from './map';

--- a/src/components/planner/actionTypes.ts
+++ b/src/components/planner/actionTypes.ts
@@ -1,5 +1,6 @@
 enum ActionTypes {
   ADD_WAYPOINT = 'ADD_WAYPOINT',
+  DELETE_WAYPOINT = 'DELETE_WAYPOINT',
 }
 
 export default ActionTypes;

--- a/src/components/planner/actions.test.ts
+++ b/src/components/planner/actions.test.ts
@@ -1,5 +1,5 @@
-import { MapPosition } from 'models';
-import { addWaypoint } from './actions';
+import { MapPosition, Waypoint } from 'models';
+import { addWaypoint, deleteWaypoint } from './actions';
 import ActionTypes from './actionTypes';
 
 describe('planner actions test', (): void => {
@@ -12,6 +12,21 @@ describe('planner actions test', (): void => {
     expect(addWaypoint(position)).toEqual({
       type: ActionTypes.ADD_WAYPOINT,
       payload: position,
+    });
+  });
+
+  it('deletes a waypoint', (): void => {
+    const waypoint: Waypoint = {
+      id: '1234',
+      position: {
+        lat: 10.0,
+        lng: 1.0,
+      },
+    };
+
+    expect(deleteWaypoint(waypoint)).toEqual({
+      type: ActionTypes.DELETE_WAYPOINT,
+      payload: waypoint,
     });
   });
 });

--- a/src/components/planner/actions.ts
+++ b/src/components/planner/actions.ts
@@ -1,4 +1,4 @@
-import { MapPosition } from 'models';
+import { MapPosition, Waypoint } from 'models';
 import ActionTypes from './actionTypes';
 
 interface AddWaypoint {
@@ -6,9 +6,19 @@ interface AddWaypoint {
   payload: MapPosition;
 }
 
-export type PlannerActionTypes = AddWaypoint;
+interface DeleteWaypoint {
+  type: ActionTypes.DELETE_WAYPOINT;
+  payload: Waypoint;
+}
+
+export type PlannerActionTypes = AddWaypoint | DeleteWaypoint;
 
 export const addWaypoint = (position: MapPosition): PlannerActionTypes => ({
   type: ActionTypes.ADD_WAYPOINT,
   payload: position,
+});
+
+export const deleteWaypoint = (waypoint: Waypoint): PlannerActionTypes => ({
+  type: ActionTypes.DELETE_WAYPOINT,
+  payload: waypoint,
 });

--- a/src/components/planner/connectedPlanner.tsx
+++ b/src/components/planner/connectedPlanner.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import { MapPosition } from 'models';
+import { MapPosition, Waypoint } from 'models';
 import { resetCurrentRoute, setCurrentRoute, RoutesActionTypes } from 'components/routes/actions';
-import { addWaypoint } from './actions';
+import { addWaypoint, deleteWaypoint } from './actions';
 import Planner, { Props } from './planner';
 
 const mapStateToProps = (state: any) => ({
@@ -14,6 +14,9 @@ const mapStateToProps = (state: any) => ({
 const mapDispatchToProps = (dispatch: Dispatch<RoutesActionTypes>) => ({
   addWaypoint: (position: MapPosition): void => {
     dispatch<any>(addWaypoint(position));
+  },
+  deleteWaypoint: (waypoint: Waypoint): void => {
+    dispatch<any>(deleteWaypoint(waypoint));
   },
   resetCurrentRoute: (): void => {
     dispatch<any>(resetCurrentRoute());

--- a/src/components/planner/planner.css.tsx
+++ b/src/components/planner/planner.css.tsx
@@ -33,7 +33,6 @@ export const Heading = styled.h1`
 
 export const WaypointList = styled.ul`
   grid-area: waypoints;
-  background: red;
 `;
 
 export const Map = styled(MapComponent)`

--- a/src/components/planner/planner.test.tsx
+++ b/src/components/planner/planner.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import * as reactRouterDom from 'react-router-dom';
-import { renderWithRouter } from 'utils/testutils';
-import { MapPosition, Route } from 'models';
+import { MapPosition, Route, Waypoint } from 'models';
 import Planner from './planner';
 
 jest.mock('react-router-dom', (): any => ({
@@ -17,6 +16,7 @@ describe('Planner tests', (): void => {
     route: null,
     waypoints: [],
     addWaypoint: jest.fn(),
+    deleteWaypoint: jest.fn(),
     resetCurrentRoute: jest.fn(),
     setCurrentRoute: jest.fn(),
   };
@@ -28,6 +28,39 @@ describe('Planner tests', (): void => {
 
     // then
     expect(getByText('Test Route')).toBeTruthy();
+  });
+
+  it('renders waypoints and deletes them on click of delete', (): void => {
+    // given
+    const spyDeleteWaypoint = jest.fn();
+    const waypoints: Waypoint[] = [
+      {
+        id: '1234',
+        note: 'Test Waypoint One',
+        position: {
+          lat: 1.0,
+          lng: 2.0,
+        },
+      },
+      {
+        id: '5678',
+        position: {
+          lat: 1.0,
+          lng: 2.0,
+        },
+      },
+    ];
+    const { getAllByTestId, getByText } = render(
+      <Planner {...defaultProps} deleteWaypoint={spyDeleteWaypoint} waypoints={waypoints} />,
+    );
+
+    // then
+    expect(getByText('Test Waypoint One')).toBeTruthy();
+    expect(getByText('Waypoint 2')).toBeTruthy();
+
+    fireEvent.click(getAllByTestId('delete-waypoint')[0]);
+
+    expect(spyDeleteWaypoint).toHaveBeenCalledWith(waypoints[0]);
   });
 
   it('renders the component and sets the current route, then reset the route on unmount', async (): Promise<void> => {

--- a/src/components/planner/planner.tsx
+++ b/src/components/planner/planner.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { MapPosition, Route, Waypoint } from 'models';
 import useMapClick from 'hooks/useMapClick';
+import WaypointTile from 'components/waypointTile/waypointTile';
 import { Container, Heading, Map, Sidebar, WaypointList } from './planner.css';
 
 export interface Props {
@@ -10,6 +11,7 @@ export interface Props {
   waypoints: Waypoint[];
 
   addWaypoint(position: MapPosition): void;
+  deleteWaypoint(waypoint: Waypoint): void;
   resetCurrentRoute(): void;
   setCurrentRoute(slug: string): void;
 }
@@ -17,6 +19,7 @@ export interface Props {
 const Planner = ({
   addWaypoint,
   className,
+  deleteWaypoint,
   resetCurrentRoute,
   route,
   setCurrentRoute,
@@ -42,7 +45,15 @@ const Planner = ({
     <Container className={className}>
       <Sidebar>
         <Heading>{route?.title}</Heading>
-        <WaypointList />
+        <WaypointList>
+          {waypoints.map((waypoint: Waypoint, idx: number) => (
+            <WaypointTile
+              key={waypoint.id}
+              onClickDelete={deleteWaypoint}
+              waypoint={{ ...waypoint, note: waypoint.note ?? `Waypoint ${idx + 1}` }}
+            />
+          ))}
+        </WaypointList>
       </Sidebar>
       <Map waypoints={waypoints} />
     </Container>

--- a/src/components/planner/reducer.test.ts
+++ b/src/components/planner/reducer.test.ts
@@ -11,7 +11,7 @@ const waypoint: Waypoint = {
 };
 
 describe('planner reducer tests', (): void => {
-  it('sets the state when updating if the api is loaded', (): void => {
+  it('sets the state when adding a waypoint', (): void => {
     const state: PlannerState = reducer(initialState, {
       type: ActionTypes.ADD_WAYPOINT,
       payload: {
@@ -19,10 +19,6 @@ describe('planner reducer tests', (): void => {
         lng: 12,
       },
     });
-    const check = {
-      ...initialState,
-      waypoints: [waypoint],
-    };
 
     expect(state).toMatchObject({
       ...state,
@@ -33,5 +29,20 @@ describe('planner reducer tests', (): void => {
         },
       ],
     });
+  });
+
+  it('sets the state when deleting a waypoint', (): void => {
+    const state: PlannerState = reducer(
+      {
+        ...initialState,
+        waypoints: [waypoint],
+      },
+      {
+        type: ActionTypes.DELETE_WAYPOINT,
+        payload: waypoint,
+      },
+    );
+
+    expect(state).toEqual(initialState);
   });
 });

--- a/src/components/planner/reducer.ts
+++ b/src/components/planner/reducer.ts
@@ -21,6 +21,16 @@ const reducer = (state: PlannerState = initialState, { payload, type }: ReduxAct
         waypoints: [...waypoints, waypoint],
       };
     }
+    case ActionTypes.DELETE_WAYPOINT: {
+      const { waypoints } = state;
+      const waypoint: Waypoint = payload;
+      const updatedWaypoints: Waypoint[] = waypoints.filter(({ id }: Waypoint) => id !== waypoint.id);
+
+      return {
+        ...state,
+        waypoints: updatedWaypoints,
+      };
+    }
     default: {
       return state;
     }

--- a/src/components/routes/routes.tsx
+++ b/src/components/routes/routes.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'models';
-import RouteTile from 'components/routetile/routetile';
+import RouteTile from 'components/routeTile/routeTile';
 import { AddRoute, Button, Container, Heading, Input, Map, RouteList, Sidebar } from './routes.css';
 
 export interface Props {

--- a/src/components/routetile/routetile.test.tsx
+++ b/src/components/routetile/routetile.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { Route } from 'models';
 import { renderWithRouter } from 'utils/testutils';
-import RouteTile, { Props } from './routetile';
+import RouteTile, { Props } from './routeTile';
 
 describe('RouteTile tests', (): void => {
   const route: Route = {

--- a/src/components/routetile/routetile.tsx
+++ b/src/components/routetile/routetile.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { Route } from 'models';
-import { Container, DeleteButton, DeleteIcon, TitleLink } from './routetile.css';
+import { Container, DeleteButton, DeleteIcon, TitleLink } from './routeTile.css';
 
 export interface Props {
   onClickDelete: (route: Route) => void;

--- a/src/components/waypointTile/waypointTile.css.tsx
+++ b/src/components/waypointTile/waypointTile.css.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import { colours } from 'styles';
+import { Bin } from 'components/icons';
+
+export const Container = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const Note = styled.span`
+  color: ${colours.primary};
+`;
+
+export const DeleteButton = styled.button``;
+
+export const DeleteIcon = styled(Bin)`
+  fill: ${colours.iconPrimary};
+  width: 2rem;
+  height: 2rem;
+`;

--- a/src/components/waypointTile/waypointTile.test.tsx
+++ b/src/components/waypointTile/waypointTile.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Waypoint } from 'models';
+import WaypointTile, { Props } from './waypointTile';
+
+const waypoint: Waypoint = {
+  id: '123',
+  note: 'Test note',
+  position: {
+    lat: 10.0,
+    lng: 11.0,
+  },
+};
+
+describe('WaypointTile tests', (): void => {
+  const defaultProps: Props = {
+    onClickDelete: jest.fn(),
+    waypoint,
+  };
+
+  it('renders the component with the correct note', (): void => {
+    // given
+    const { getByText } = render(<WaypointTile {...defaultProps} />);
+
+    // then
+    expect(getByText('Test note')).toBeTruthy();
+  });
+
+  it('executes a callback on click delete', (): void => {
+    // given
+    const spyOnClickDelete = jest.fn();
+    const { getByTestId } = render(<WaypointTile {...defaultProps} onClickDelete={spyOnClickDelete} />);
+
+    // then
+    fireEvent.click(getByTestId('delete-waypoint'));
+    expect(spyOnClickDelete).toHaveBeenCalledWith(waypoint);
+  });
+});

--- a/src/components/waypointTile/waypointTile.tsx
+++ b/src/components/waypointTile/waypointTile.tsx
@@ -1,0 +1,26 @@
+import React, { useCallback } from 'react';
+import { Waypoint } from 'models';
+import { Container, DeleteButton, DeleteIcon, Note } from './waypointTile.css';
+
+export interface Props {
+  waypoint: Waypoint;
+  onClickDelete: (waypoint: Waypoint) => void;
+}
+
+const WaypointTile = ({ onClickDelete, waypoint }: Props): JSX.Element => {
+  const { id, note } = waypoint;
+  const cbOnClickDelete = useCallback((): void => {
+    onClickDelete(waypoint);
+  }, [id]);
+
+  return (
+    <Container>
+      <Note>{note}</Note>
+      <DeleteButton data-testid="delete-waypoint" onClick={cbOnClickDelete}>
+        <DeleteIcon />
+      </DeleteButton>
+    </Container>
+  );
+};
+
+export default WaypointTile;

--- a/src/utils/testutils.tsx
+++ b/src/utils/testutils.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Store } from 'redux';
 import { BrowserRouter } from 'react-router-dom';
 import configureMockStore, { MockStoreCreator } from 'redux-mock-store';
-import { fireEvent, render, RenderResult } from '@testing-library/react';
+import { render, RenderResult } from '@testing-library/react';
 import { RoutesState } from 'models';
 import { initialState } from 'components/routes/reducer';
 


### PR DESCRIPTION
#### What is this?
This PR adds a waypoint tile that is rendered in the side bar for the planner. Waypoints can also be deleted. Tests for the component, reducer and actions have been added.