### PR TITLE
feat: markers now draggable across map

### DIFF
--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -48,14 +48,17 @@ const Map = ({
 
   useEffect((): void => {
     if (map) {
+      // get the new coords and set up a new polyline
       const coords: google.maps.LatLng[] = waypointsToLatLng(waypoints);
       const newPolyLine = initPolyline(coords);
 
+      // if we have an existing polyline, nuke it
       if (polyLine) {
         polyLine.setMap(null);
         setPolyLine(null);
       }
 
+      // then set the new poly line to the map and update the state
       newPolyLine.setMap(map);
       setPolyLine(newPolyLine);
     }

--- a/src/components/planner/actionTypes.ts
+++ b/src/components/planner/actionTypes.ts
@@ -1,6 +1,7 @@
 enum ActionTypes {
   ADD_WAYPOINT = 'ADD_WAYPOINT',
   DELETE_WAYPOINT = 'DELETE_WAYPOINT',
+  UPDATE_WAYPOINT = 'UPDATE_WAYPOINT',
 }
 
 export default ActionTypes;

--- a/src/components/planner/actions.test.ts
+++ b/src/components/planner/actions.test.ts
@@ -1,32 +1,40 @@
-import { MapPosition, Waypoint } from 'models';
-import { addWaypoint, deleteWaypoint } from './actions';
+import { Waypoint } from 'models';
+import { addWaypoint, deleteWaypoint, updateWaypoint } from './actions';
 import ActionTypes from './actionTypes';
 
 describe('planner actions test', (): void => {
-  it('adds a waypoint', (): void => {
-    const position: MapPosition = {
-      lat: 10.0,
-      lng: 10.0,
-    };
+  const marker: google.maps.Marker = {} as google.maps.Marker;
 
-    expect(addWaypoint(position)).toEqual({
+  it('adds a waypoint', (): void => {
+    expect(addWaypoint(marker)).toEqual({
       type: ActionTypes.ADD_WAYPOINT,
-      payload: position,
+      payload: {},
     });
   });
 
   it('deletes a waypoint', (): void => {
     const waypoint: Waypoint = {
       id: '1234',
-      position: {
-        lat: 10.0,
-        lng: 1.0,
-      },
+      dateUpdated: new Date(),
+      marker,
     };
 
     expect(deleteWaypoint(waypoint)).toEqual({
       type: ActionTypes.DELETE_WAYPOINT,
       payload: waypoint,
+    });
+  });
+
+  it('updates a waypoint', (): void => {
+    const coordinate: google.maps.LatLngLiteral = {
+      lat: 1.0,
+      lng: 1.0,
+    };
+    const uuid = '123';
+
+    expect(updateWaypoint(coordinate, uuid)).toEqual({
+      type: ActionTypes.UPDATE_WAYPOINT,
+      payload: { coordinate, uuid },
     });
   });
 });

--- a/src/components/planner/actions.ts
+++ b/src/components/planner/actions.ts
@@ -1,4 +1,4 @@
-import { Waypoint } from 'models';
+import { MarkerUpdatedDetail, Waypoint } from 'models';
 import ActionTypes from './actionTypes';
 
 interface AddWaypoint {
@@ -11,7 +11,12 @@ interface DeleteWaypoint {
   payload: Waypoint;
 }
 
-export type PlannerActionTypes = AddWaypoint | DeleteWaypoint;
+interface UpdateWaypoint {
+  type: ActionTypes.UPDATE_WAYPOINT;
+  payload: MarkerUpdatedDetail;
+}
+
+export type PlannerActionTypes = AddWaypoint | DeleteWaypoint | UpdateWaypoint;
 
 export const addWaypoint = (marker: google.maps.Marker): PlannerActionTypes => ({
   type: ActionTypes.ADD_WAYPOINT,
@@ -21,4 +26,9 @@ export const addWaypoint = (marker: google.maps.Marker): PlannerActionTypes => (
 export const deleteWaypoint = (waypoint: Waypoint): PlannerActionTypes => ({
   type: ActionTypes.DELETE_WAYPOINT,
   payload: waypoint,
+});
+
+export const updateWaypoint = (coordinate: google.maps.LatLngLiteral, uuid: string): PlannerActionTypes => ({
+  type: ActionTypes.UPDATE_WAYPOINT,
+  payload: { coordinate, uuid },
 });

--- a/src/components/planner/connectedPlanner.tsx
+++ b/src/components/planner/connectedPlanner.tsx
@@ -3,7 +3,7 @@ import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import { Waypoint } from 'models';
 import { resetCurrentRoute, setCurrentRoute, RoutesActionTypes } from 'components/routes/actions';
-import { addWaypoint, deleteWaypoint } from './actions';
+import { addWaypoint, deleteWaypoint, updateWaypoint } from './actions';
 import Planner, { Props } from './planner';
 
 const mapStateToProps = (state: any) => ({
@@ -24,6 +24,9 @@ const mapDispatchToProps = (dispatch: Dispatch<RoutesActionTypes>) => ({
   },
   setCurrentRoute: (slug: string): void => {
     dispatch<any>(setCurrentRoute(slug));
+  },
+  updateWaypoint: (coordinate: google.maps.LatLngLiteral, uuid: string): void => {
+    dispatch<any>(updateWaypoint(coordinate, uuid));
   },
 });
 

--- a/src/components/planner/planner.test.tsx
+++ b/src/components/planner/planner.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import * as reactRouterDom from 'react-router-dom';
 import * as googleServices from 'services/googlemaps';
-import { Route, Waypoint } from 'models';
+import { MarkerUpdatedDetail, Route, Waypoint } from 'models';
 import Planner from './planner';
 
 jest.mock('react-router-dom', (): any => ({
@@ -22,6 +22,7 @@ describe('Planner tests', (): void => {
     deleteWaypoint: jest.fn(),
     resetCurrentRoute: jest.fn(),
     setCurrentRoute: jest.fn(),
+    updateWaypoint: jest.fn(),
   };
   const mockedMarker = {
     setMap: jest.fn(),
@@ -43,11 +44,13 @@ describe('Planner tests', (): void => {
     const waypoints: Waypoint[] = [
       {
         id: '1234',
+        dateUpdated: new Date('1982-04-26'),
         note: 'Test Waypoint One',
         marker: mockedMarker,
       },
       {
         id: '5678',
+        dateUpdated: new Date('1983-05-27'),
         marker: mockedMarker,
       },
     ];
@@ -114,6 +117,31 @@ describe('Planner tests', (): void => {
       new CustomEvent<google.maps.Marker>('map:markerAdded', { detail: mockedMarker }),
     );
     expect(spyAddWaypoint).toHaveBeenCalledWith(mockedMarker);
+
+    // cleanup
+    spyUseParams.mockRestore();
+  });
+
+  it('calls to update a waypoint', (): void => {
+    // given
+    const coordinate: google.maps.LatLngLiteral = {
+      lat: 23.0,
+      lng: 22.0,
+    };
+    const uuid = '123';
+    const spyUseParams = jest.spyOn(reactRouterDom, 'useParams').mockReturnValue({ slug: 'test' });
+    const spyUpdateWaypoint = jest.fn();
+
+    render(<Planner {...defaultProps} updateWaypoint={spyUpdateWaypoint} />);
+
+    // then
+    fireEvent(
+      window,
+      new CustomEvent<MarkerUpdatedDetail>('map:markerUpdated', {
+        detail: { coordinate, uuid },
+      }),
+    );
+    expect(spyUpdateWaypoint).toHaveBeenCalledWith(coordinate, uuid);
 
     // cleanup
     spyUseParams.mockRestore();

--- a/src/components/planner/planner.tsx
+++ b/src/components/planner/planner.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { Route, Waypoint } from 'models';
-import { useMarkerAdded } from 'hooks/useMap';
+import { MarkerUpdatedDetail, Route, Waypoint } from 'models';
+import { useMarkerAdded, useMarkerUpdated } from 'hooks/useMap';
 import { deleteMarkerFromMap } from 'services/googlemaps';
 import WaypointTile from 'components/waypointTile/waypointTile';
 import { Container, Heading, Map, Sidebar, WaypointList } from './planner.css';
@@ -16,6 +16,7 @@ export interface Props {
   deleteWaypoint(waypoint: Waypoint): void;
   resetCurrentRoute(): void;
   setCurrentRoute(slug: string): void;
+  updateWaypoint(coordinate: google.maps.LatLngLiteral, uuid: string): void;
 }
 
 const Planner = ({
@@ -25,6 +26,7 @@ const Planner = ({
   resetCurrentRoute,
   route,
   setCurrentRoute,
+  updateWaypoint,
   waypoints,
 }: Props): JSX.Element => {
   const { slug } = useParams<{ slug?: string }>();
@@ -47,6 +49,12 @@ const Planner = ({
     const marker: google.maps.Marker = e.detail;
 
     addWaypoint(marker);
+  });
+
+  useMarkerUpdated((e: CustomEvent<MarkerUpdatedDetail>): void => {
+    const { coordinate, uuid } = e.detail;
+
+    updateWaypoint(coordinate, uuid);
   });
 
   return (

--- a/src/components/planner/reducer.test.ts
+++ b/src/components/planner/reducer.test.ts
@@ -1,14 +1,17 @@
 import { PlannerState, Waypoint } from 'models';
 import ActionTypes from './actionTypes';
+import * as googleServices from 'services/googlemaps';
 import reducer, { initialState } from './reducer';
 
 const waypoint: Waypoint = {
+  dateUpdated: new Date(),
   id: '123',
   marker: {} as google.maps.Marker,
 };
 
 describe('planner reducer tests', (): void => {
   it('sets the state when adding a waypoint', (): void => {
+    const spyAddMarkerDragEndListener = jest.spyOn(googleServices, 'addMarkerDragEndListener').mockImplementation();
     const state: PlannerState = reducer(initialState, {
       type: ActionTypes.ADD_WAYPOINT,
       payload: {} as google.maps.Marker,
@@ -19,11 +22,16 @@ describe('planner reducer tests', (): void => {
       waypoints: [
         {
           ...waypoint,
+          dateUpdated: expect.any(Date),
           id: expect.any(String),
           marker: expect.any(Object),
         },
       ],
     });
+    expect(spyAddMarkerDragEndListener).toHaveBeenCalled();
+
+    // cleanup
+    spyAddMarkerDragEndListener.mockRestore();
   });
 
   it('sets the state when deleting a waypoint', (): void => {
@@ -39,5 +47,71 @@ describe('planner reducer tests', (): void => {
     );
 
     expect(state).toEqual(initialState);
+  });
+
+  it('sets the state when updating a waypoint', (): void => {
+    const sypSetPosition = jest.fn();
+    const waypoints: Waypoint[] = [
+      {
+        ...waypoint,
+        marker: {
+          setPosition: sypSetPosition,
+        } as any,
+      },
+    ];
+    const state: PlannerState = reducer(
+      {
+        ...initialState,
+        waypoints,
+      },
+      {
+        type: ActionTypes.UPDATE_WAYPOINT,
+        payload: {
+          coordinate: {
+            lat: 10.0,
+            lng: 10.0,
+          },
+          uuid: '123',
+        },
+      },
+    );
+
+    expect(state).toEqual({
+      ...initialState,
+      waypoints,
+    });
+    expect(sypSetPosition).toHaveBeenCalled();
+  });
+
+  it('does not set the state when updating a waypoint that was not found', (): void => {
+    const sypSetPosition = jest.fn();
+    const waypoints: Waypoint[] = [
+      {
+        ...waypoint,
+        id: '567',
+        marker: {
+          setPosition: sypSetPosition,
+        } as any,
+      },
+    ];
+
+    reducer(
+      {
+        ...initialState,
+        waypoints,
+      },
+      {
+        type: ActionTypes.UPDATE_WAYPOINT,
+        payload: {
+          coordinate: {
+            lat: 10.0,
+            lng: 10.0,
+          },
+          uuid: '123',
+        },
+      },
+    );
+
+    expect(sypSetPosition).not.toHaveBeenCalled();
   });
 });

--- a/src/components/planner/reducer.ts
+++ b/src/components/planner/reducer.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { PlannerState, ReduxAction, Waypoint } from 'models';
+import { addMarkerDragEndListener } from 'services/googlemaps';
 import ActionTypes from './actionTypes';
 
 export const initialState: PlannerState = {
@@ -10,17 +11,23 @@ const reducer = (state: PlannerState = initialState, { payload, type }: ReduxAct
   switch (type) {
     case ActionTypes.ADD_WAYPOINT: {
       const marker: google.maps.Marker = payload;
+      const id = uuidv4();
       const waypoint: Waypoint = {
-        id: uuidv4(),
+        dateUpdated: new Date(),
+        id,
         marker,
       };
       const { waypoints } = state;
+
+      // TODO: Put this somewhere better
+      addMarkerDragEndListener(marker, id);
 
       return {
         ...state,
         waypoints: [...waypoints, waypoint],
       };
     }
+
     case ActionTypes.DELETE_WAYPOINT: {
       const { waypoints } = state;
       const waypoint: Waypoint = payload;
@@ -31,6 +38,26 @@ const reducer = (state: PlannerState = initialState, { payload, type }: ReduxAct
         waypoints: updatedWaypoints,
       };
     }
+
+    case ActionTypes.UPDATE_WAYPOINT: {
+      const { waypoints } = state;
+      const { coordinate, uuid } = payload;
+      const foundIndex: number = waypoints.findIndex(({ id }: Waypoint) => id === uuid);
+
+      if (foundIndex !== -1) {
+        const waypointToUpdate: Waypoint = waypoints[foundIndex];
+
+        waypointToUpdate.marker.setPosition(coordinate);
+        waypointToUpdate.dateUpdated = new Date();
+        waypoints[foundIndex] = waypointToUpdate;
+      }
+
+      return {
+        ...state,
+        waypoints: [...waypoints],
+      };
+    }
+
     default: {
       return state;
     }

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -1,20 +1,18 @@
 import { useEffect } from 'react';
-// import { MapPosition } from 'models';
-
-// const useMapClick = (cb: (e: CustomEvent<MapPosition>) => void): void => {
-//   useEffect((): (() => void) => {
-//     window.addEventListener('map:onclick', cb as EventListener);
-
-//     return (): void => window.removeEventListener('map:onclick', cb as EventListener);
-//   }, [cb]);
-// };
-
-// export default useMapClick;
+import { MarkerUpdatedDetail } from 'models';
 
 export const useMarkerAdded = (cb: (e: CustomEvent<google.maps.Marker>) => void): void => {
   useEffect((): (() => void) => {
     window.addEventListener('map:markerAdded', cb as EventListener);
 
     return (): void => window.removeEventListener('map:markerAdded', cb as EventListener);
+  });
+};
+
+export const useMarkerUpdated = (cb: (e: CustomEvent<MarkerUpdatedDetail>) => void): void => {
+  useEffect((): (() => void) => {
+    window.addEventListener('map:markerUpdated', cb as EventListener);
+
+    return (): void => window.removeEventListener('map:markerUpdated', cb as EventListener);
   });
 };

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -4,9 +4,15 @@ export interface MapPosition {
 }
 
 export interface Waypoint {
+  dateUpdated: Date;
   id: string;
   note?: string;
   marker: google.maps.Marker;
+}
+
+export interface MarkerUpdatedDetail {
+  coordinate: google.maps.LatLngLiteral;
+  uuid: string;
 }
 
 export interface Route {


### PR DESCRIPTION
#### What is this?
This PR adds functionality to allow route markers to be dragged, so they can update the route and its poly-lines when markers are moved and dropped.