### PR TITLE
fix: ensure map polylines loaded if there are waypoints

### DIFF
--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -35,7 +35,6 @@ const Map = ({
 
     if (apiLoaded && mapRef.current) {
       const map: google.maps.Map<HTMLDivElement> = initMap(mapRef.current);
-
       setMap(map);
     }
   }, [apiLoaded, mapRef]);
@@ -47,7 +46,7 @@ const Map = ({
   }, [map, canEdit]);
 
   useEffect((): void => {
-    if (map) {
+    if (map && waypoints.length) {
       // get the new coords and set up a new polyline
       const coords: google.maps.LatLng[] = waypointsToLatLng(waypoints);
       const newPolyLine = initPolyline(coords);


### PR DESCRIPTION
#### What is this?
This fixes a bug by ensuring that polylines for the map are only rendered when there are waypoints.