### PR TITLE
fix: set stricter typing

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { JSXChildren } from 'models';
 import { Container } from './button.css';
 
 export interface Props {
-  children?: any;
+  children?: JSXChildren;
   className?: string;
   disabled?: boolean;
   onClick: () => void;

--- a/src/components/map/connectedMap.tsx
+++ b/src/components/map/connectedMap.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
+import { AppState } from 'models';
 import { MapActionTypes, setApiLoaded, setMap } from './actions';
 import Map, { Props } from './map';
 
-const mapStateToProps = (state: any) => ({
+const mapStateToProps = (state: AppState) => ({
   apiLoaded: state.mapState.apiLoaded,
   map: state.mapState.map,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<MapActionTypes>) => ({
   setApiLoaded: (apiLoaded: boolean): void => {
-    dispatch<any>(setApiLoaded(apiLoaded));
+    dispatch<MapActionTypes>(setApiLoaded(apiLoaded));
   },
   setMap: (map: google.maps.Map<HTMLDivElement>): void => {
-    dispatch<any>(setMap(map));
+    dispatch<MapActionTypes>(setMap(map));
   },
 });
 

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -25,8 +25,8 @@ export interface Route {
 }
 
 export interface ReduxAction {
-  error?: any;
-  payload?: any;
+  error?: Error;
+  payload?: unknown;
   type: string;
 }
 
@@ -36,7 +36,7 @@ export interface PlannerState {
 
 export interface RoutesState {
   currentRoute: Route | null;
-  error: any;
+  error: Error;
   newRouteTitle: string;
   pending: boolean;
   routes: Route[];
@@ -44,5 +44,11 @@ export interface RoutesState {
 
 export interface MapState {
   apiLoaded: boolean;
-  map: google.maps.Map | null;
+  map: google.maps.Map<HTMLDivElement> | null;
+}
+
+export interface AppState {
+  mapState: MapState;
+  plannerState: PlannerState;
+  routesState: RoutesState;
 }

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { RoutesState } from './interfaces';
+import { MapState, PlannerState, RoutesState } from './interfaces';
 
 export type Colours = {
   primary: string;
@@ -24,6 +24,8 @@ export type FontWeights = {
   light: number;
 };
 
-export type AppState = RoutesState;
+export type JSXChildren = JSX.Element | JSX.Element[];
 
-export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, AppState, unknown, Action<string>>;
+export type AppStates = MapState | PlannerState | RoutesState;
+
+export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, AppStates, unknown, Action<string>>;

--- a/src/views/planner/connectedPlanner.tsx
+++ b/src/views/planner/connectedPlanner.tsx
@@ -1,32 +1,32 @@
 import React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import { Waypoint } from 'models';
+import { AppState, Waypoint } from 'models';
 import { resetCurrentRoute, setCurrentRoute, RoutesActionTypes } from 'views/routes/actions';
-import { addWaypoint, deleteWaypoint, updateWaypoint } from './actions';
+import { addWaypoint, deleteWaypoint, PlannerActionTypes, updateWaypoint } from './actions';
 import Planner, { Props } from './planner';
 
-const mapStateToProps = (state: any) => ({
+const mapStateToProps = (state: AppState) => ({
   map: state.mapState.map,
   route: state.routesState.currentRoute,
   waypoints: state.plannerState.waypoints,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<RoutesActionTypes>) => ({
+const mapDispatchToProps = (dispatch: Dispatch<RoutesActionTypes | PlannerActionTypes>) => ({
   addWaypoint: (marker: google.maps.Marker): void => {
-    dispatch<any>(addWaypoint(marker));
+    dispatch<PlannerActionTypes>(addWaypoint(marker));
   },
   deleteWaypoint: (waypoint: Waypoint): void => {
-    dispatch<any>(deleteWaypoint(waypoint));
+    dispatch<PlannerActionTypes>(deleteWaypoint(waypoint));
   },
   resetCurrentRoute: (): void => {
-    dispatch<any>(resetCurrentRoute());
+    dispatch<RoutesActionTypes>(resetCurrentRoute());
   },
   setCurrentRoute: (slug: string): void => {
-    dispatch<any>(setCurrentRoute(slug));
+    dispatch<RoutesActionTypes>(setCurrentRoute(slug));
   },
   updateWaypoint: (coordinate: google.maps.LatLngLiteral, uuid: string): void => {
-    dispatch<any>(updateWaypoint(coordinate, uuid));
+    dispatch<PlannerActionTypes>(updateWaypoint(coordinate, uuid));
   },
 });
 

--- a/src/views/routes/connectedRoutes.tsx
+++ b/src/views/routes/connectedRoutes.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import { Route } from 'models';
+import { AppState, Route } from 'models';
 import { addRoute, deleteRoute, updateNewRouteTitle, RoutesActionTypes } from './actions';
 import Routes, { Props } from './routes';
 
-const mapStateToProps = (state: any) => ({
+const mapStateToProps = (state: AppState) => ({
   error: state.routesState.error,
   newRouteTitle: state.routesState.newRouteTitle,
   pending: state.routesState.pending,
@@ -14,13 +14,13 @@ const mapStateToProps = (state: any) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch<RoutesActionTypes>) => ({
   addRoute: (): void => {
-    dispatch<any>(addRoute());
+    dispatch<RoutesActionTypes>(addRoute());
   },
   deleteRoute: (route: Route): void => {
-    dispatch<any>(deleteRoute(route));
+    dispatch<RoutesActionTypes>(deleteRoute(route));
   },
   updateNewRouteTitle: (title: string): void => {
-    dispatch<any>(updateNewRouteTitle(title));
+    dispatch<RoutesActionTypes>(updateNewRouteTitle(title));
   },
 });
 

--- a/src/views/routes/routes.tsx
+++ b/src/views/routes/routes.tsx
@@ -9,7 +9,7 @@ export interface Props {
   updateNewRouteTitle(title: string): void;
 
   className?: string;
-  error?: any;
+  error?: Error;
   newRouteTitle: string;
   pending: boolean;
   routes: Route[];


### PR DESCRIPTION
#### What is this?
This PR corrects some of the warnings (implementation only, not tests) and removes 'any' for function argument types and sets them to their more suitable TypeScript types.

**Note**: I tried doing this for the tests, but still need to figure out a way to mock return values that only contain the properties I want, without TypeScript highlighting that other properties for a return type are missing. This is why I added 'as any' in the first place, but I would prefer a more robust solution.